### PR TITLE
Improves how ES6 modules are built

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -5,9 +5,6 @@ module.exports = ->
     'jshint'
     'chrome-extension'
     'firefox-extension'
-    'es6'
-    'shell:chrome-extension'
-    'mozilla-cfx-xpi'
   ]
 
   @registerTask 'test', [
@@ -21,6 +18,8 @@ module.exports = ->
     'compress:chrome-extension'
     'copy:chrome-extension'
     'stylus:chrome-extension'
+    'es6:chrome-extension'
+    'shell:chrome-extension'
   ]
 
   @registerTask 'firefox-extension', [
@@ -28,4 +27,6 @@ module.exports = ->
     'copy:firefox-extension'
     'stylus:firefox-extension'
     'targethtml:firefox'
+    'es6:firefox-extension'
+    'mozilla-cfx-xpi'
   ]

--- a/build/tasks/es6.coffee
+++ b/build/tasks/es6.coffee
@@ -1,30 +1,26 @@
 transpiler = require 'es6-module-transpiler'
 
 buildES6 = (options) ->
-  # Containers can't have multiple write calls, so instead create two
-  # different containers to output.
-
   container = new transpiler.Container(
     resolvers: [new transpiler.FileResolver([options.path])]
     formatter: new transpiler.formatters.bundle
   )
 
   container.getModule options.module
-  container.write 'chrome-extension/dist/tipsy/' + options.chrome
 
-  container = new transpiler.Container(
-    resolvers: [new transpiler.FileResolver([options.path])]
-    formatter: new transpiler.formatters.bundle
-  )
-
-  container.getModule options.module
-  container.write 'firefox-extension/dist/tipsy/data/' + options.firefox
+  if options.target is "chrome-extension"
+    container.write "chrome-extension/dist/tipsy/" + options.chrome
+  else if options.target is "firefox-extension"
+    container.write 'firefox-extension/dist/tipsy/data/' + options.firefox
 
 module.exports = ->
   @registerTask 'es6', 'Compiles ES6 modules.', ->
 
+    target = @args[0]
+
     # Extension.
     buildES6
+      target: target
       path: 'shared/scripts/lib'
       module: 'index'
       chrome: 'js/tipsy.js'
@@ -32,6 +28,7 @@ module.exports = ->
 
     # Background.
     buildES6
+      target: target
       path: 'shared/scripts'
       module: 'background'
       chrome: 'js/background.js'
@@ -39,6 +36,7 @@ module.exports = ->
 
     # ContentScript.
     buildES6
+      target: target
       path: 'shared/scripts'
       module: 'contentscript'
       chrome: 'js/contentscript.js'


### PR DESCRIPTION
Provides for a better structure in the build process.  Before ES6 lumped
Chrome and Firefox together which was slow and conflating.  Now ES6 will
build for Chrome and Firefox separately.
