### PR TITLE
Ensure that pages are tracked with more precision

### DIFF
--- a/shared/scripts/lib/components/log-table/log-table.html
+++ b/shared/scripts/lib/components/log-table/log-table.html
@@ -16,7 +16,7 @@
     </tr>
   {%else%}
     {%each entries as entry key%}
-    <tr data-key="{{key}}" class="{{entry|hasAuthor}}-author"> 
+    <tr data-host="{{entry.host}}" data-key="{{key}}" class="{{entry|hasAuthor}}-author"> 
       <td>
         {{entry.host}}
       </td>
@@ -28,7 +28,7 @@
         {%endif%}
       </td>
       <td>{{entry.entries.length}}</td>
-      <td data-sort="{{entry.entries|timeSpent 'true'}}">{{entry.entries|timeSpent}}</td>
+      <td data-sort="{{entry.entries|timeSpent 'true'}}" class="timeSpent">{{entry.entries|timeSpent}}</td>
       <td data-sort="{{entry.entries|findLast|formatAccessTime 'true'}}">{{entry.entries|findLast|formatAccessTime}}</td>
     </tr>
     {%endeach%}

--- a/shared/scripts/lib/index.js
+++ b/shared/scripts/lib/index.js
@@ -120,3 +120,27 @@ setTab();
 
 // Ensure that the tab is changed whenever the hash value is updated.
 window.addEventListener('hashchange', setTab, true);
+
+// Use a more precise formatter for huamanize.
+// https://github.com/moment/moment/issues/348#issuecomment-6535794
+moment.lang('precise-en', {
+  relativeTime : {
+    future : "in %s",
+    past : "%s ago",
+    // See: https://github.com/timrwood/moment/pull/232#issuecomment-4699806
+    s : "%d seconds",
+    m : "a minute",
+    mm : "%d minutes",
+    h : "an hour",
+    hh : "%d hours",
+    d : "a day",
+    dd : "%d days",
+    M : "a month",
+    MM : "%d months",
+    y : "a year",
+    yy : "%d years"
+  }
+});
+
+// Set this precise formatter globally.
+moment.lang('precise-en');

--- a/shared/scripts/lib/watcher.js
+++ b/shared/scripts/lib/watcher.js
@@ -86,6 +86,10 @@ if (environment === 'chrome') {
     else if (tabs[tabId] && changeInfo.url) {
       stop(tabs[tabId].tab);
     }
+
+    else if (tabs[tabId]) {
+      start(tabs[tabId]);
+    }
   });
 
   // When the tab is removed, stop the timer.

--- a/test/integration/tests/watcher.js
+++ b/test/integration/tests/watcher.js
@@ -17,11 +17,6 @@ describe('watcher', function() {
               return driver.click('.show.author');
             })
             .then(function() {
-              return driver.wait(function() {
-                return document.querySelectorAll('table tr.no-author').length;
-              })
-            })
-            .then(function() {
               return driver.execute(function() {
                 return document.querySelectorAll('table tr.no-author').length;
               });
@@ -46,6 +41,11 @@ describe('watcher', function() {
               return driver.refresh();
             })
             .then(function() {
+              return driver.wait(function() {
+                return document.querySelectorAll('.show.author').length;
+              })
+            })
+            .then(function() {
               return driver.click('.show.author');
             })
             .then(function() {
@@ -57,6 +57,40 @@ describe('watcher', function() {
             }).then(resolve, reject);
         }, 1000);
       });
-    })
+    });
+  });
+
+  it('will report correct time when page is visited for five seconds', function() {
+    this.timeout(20000);
+
+    var driver = this.extensionDriver;
+
+    return driver.get('http://google.com/').then(function() {
+      return new Promise(function(resolve, reject) {
+        return driver.wait(function(prev) {
+          return Date.now() - prev > 5000;
+        }, Date.now())
+        .then(function() {
+          return driver.navigate('html/index.html#log')
+        })
+        .then(function() {
+          return driver.refresh();
+        })
+        .then(function() {
+          return driver.click('.show.author');
+        })
+        .then(function() {
+          return driver.execute(function() {
+            var tr =  document.querySelector('[data-host="google.com"]');
+            if (!tr) { return; }
+            return tr.querySelector('.timeSpent').innerHTML;
+          });
+        }).then(function(value) {
+          var actual = parseInt(value, 10);
+
+          assert.equal(actual, 7, 'Meets expected threshold');
+        }).then(resolve, reject);
+      });
+    });
   });
 });

--- a/test/integration/tests/watcher.js
+++ b/test/integration/tests/watcher.js
@@ -65,7 +65,7 @@ describe('watcher', function() {
 
     var driver = this.extensionDriver;
 
-    return driver.get('http://google.com/').then(function() {
+    return driver.get('http://reddit.com/').then(function() {
       return new Promise(function(resolve, reject) {
         return driver.wait(function(prev) {
           return Date.now() - prev > 5000;
@@ -81,14 +81,14 @@ describe('watcher', function() {
         })
         .then(function() {
           return driver.execute(function() {
-            var tr =  document.querySelector('[data-host="google.com"]');
+            var tr =  document.querySelector('[data-host="reddit.com"]');
             if (!tr) { return; }
             return tr.querySelector('.timeSpent').innerHTML;
           });
         }).then(function(value) {
           var actual = parseInt(value, 10);
 
-          assert.equal(actual, 7, 'Meets expected threshold');
+          assert.equal(actual, 5, 'Reports the correct time visited.');
         }).then(resolve, reject);
       });
     });


### PR DESCRIPTION
I added [data-host] to the rows to make it easier to select a particular
host with the DOM.  This made the selectors much simplier in the tests.

I changed the moment humanizer formatter to show more accuracy.  Before
it was 'a few seconds', now it's '5 seconds'.

This also adds in a test asserting basic tracking.  I adjusted the watcher code to always start tracking a new tab in the onUpdated event.