### PR TITLE
Use Tipsy redirect script

### DIFF
--- a/shared/scripts/lib/index.js
+++ b/shared/scripts/lib/index.js
@@ -68,10 +68,10 @@ function setTab() {
     // Otherwise we can assume the payment was successful.  We can now
     // remove all the items from the storage.
     return storage.get('settings').then(function(settings) {
-      storage.get('log').then(function(resp) {
+      return storage.get('log').then(function(resp) {
         // Filter out these items.
         resp[host] = resp[host].filter(function(entry) {
-          return entry.tab.url !== url;
+          return entry.tab && entry.tab.url !== url;
         });
 
         return storage.set('log', resp).then(function() {
@@ -87,8 +87,11 @@ function setTab() {
         });
       });
     }).catch(function() {
-      window.alert('Potential error removing the donation, please manually' +
-        'update');
+      // Remove the query string from the url.
+      history.replaceState({}, "", location.href.split("?")[0]);
+
+      // Redirect to donations.
+      location.href = '#donations';
     });
   }
   else {

--- a/shared/scripts/lib/processors/dwolla.js
+++ b/shared/scripts/lib/processors/dwolla.js
@@ -2,7 +2,7 @@
 
 export function inject($el, amount, token) {
   var base = location.href.split('#')[0];
-  var redirect = 'http://tbranyen.com:9999/redirect/' +
+  var redirect = 'http://tipsy.csail.mit.edu/redirect/' +
     encodeURIComponent(base) + '/' + 'Dwolla user' + '/' + amount;
 
   var src = 'https://www.dwolla.com/scripts/button.min.js';

--- a/shared/scripts/lib/processors/dwolla.js
+++ b/shared/scripts/lib/processors/dwolla.js
@@ -1,10 +1,12 @@
 'use strict';
 
 export function inject($el, amount, token) {
+  var root = 'http://tipsy.csail.mit.edu/redirect';
   var base = location.href.split('#')[0];
-  var redirect = 'http://tipsy.csail.mit.edu/redirect/' +
-    encodeURIComponent(base) + '/' + 'Dwolla user' + '/' + amount;
+  base = base.replace(/\//g, '$');
+  base = encodeURIComponent(base);
 
+  var redirect = [root, base, 'Dwolla user', amount].join('/');
   var src = 'https://www.dwolla.com/scripts/button.min.js';
 
   // If we're in testing, swap the token with our test account.
@@ -33,6 +35,10 @@ export function inject($el, amount, token) {
   return {
     update: function(amount) {
       script.next('a.d-btn').attr('data-amount', amount.slice(1));
+
+      // Update the redirect as well.
+      var redirect = [root, base, 'Dwolla user', amount].join('/');
+      script.next('a.d-btn').attr('data-redirect', redirect);
     }
   };
 }

--- a/shared/scripts/lib/processors/paypal.js
+++ b/shared/scripts/lib/processors/paypal.js
@@ -1,7 +1,7 @@
 'use strict';
 
 export function inject($el, amount, email) {
-  var base = 'http://tbranyen.com:9999/redirect/';
+  var base = 'http://tipsy.csail.mit.edu/redirect/';
   var root = base + encodeURIComponent(location.href.split('#')[0]);
   var redirect = [root, email, amount].join('/');
 

--- a/shared/scripts/lib/processors/paypal.js
+++ b/shared/scripts/lib/processors/paypal.js
@@ -1,9 +1,12 @@
 'use strict';
 
 export function inject($el, amount, email) {
-  var base = 'http://tipsy.csail.mit.edu/redirect/';
-  var root = base + encodeURIComponent(location.href.split('#')[0]);
-  var redirect = [root, email, amount].join('/');
+  var root = 'http://tipsy.csail.mit.edu/redirect';
+  var base = location.href.split('#')[0];
+  base = base.replace(/\//g, '$');
+  base = encodeURIComponent(base);
+
+  var redirect = [root, base, email, amount].join('/');
 
   var form = $('<form>').attr({
     name: '_xclick',
@@ -24,7 +27,7 @@ export function inject($el, amount, email) {
     currency_code: 'USD',
     item_name: 'Tispy',
     return: redirect,
-    cancel_return: redirect
+    cancel_return: redirect + '/cancel'
   };
 
   // Convert all hidden to inputs.
@@ -45,9 +48,9 @@ export function inject($el, amount, email) {
       hidden.amount.attr('value', amount);
 
       // Update the redirect as well.
-      var redirect = [root, email, amount].join('/');
+      var redirect = [root, base, email, amount].join('/');
       hidden.return.attr('value', redirect);
-      hidden.cancel_return.attr('value', redirect);
+      hidden.cancel_return.attr('value', redirect + '/cancel');
     }
   };
 }


### PR DESCRIPTION
This changes over to using the MIT Tipsy server for script redirection.  We are not able to use querystrings for redirection, it must be part of the URL pathname.  I've noticed that MIT's servers decode the URL encoding and interpret the slashes incorrectly (as they are part of a pathname).   So I do not think this will work as-is.  Might need to replace `/` with a different character.

So basically:

Works:

``` url
http://tipsy.csail.mit.edu/redirect/chrome-extension
```

Doesn't work:

``` url
http://tipsy.csail.mit.edu/redirect/chrome-extension%3A%2F%2Ftest%2F
```