### PR TITLE
Fixes issue with internal istanbul upgrade

### DIFF
--- a/build/tasks/istanbul.coffee
+++ b/build/tasks/istanbul.coffee
@@ -4,7 +4,7 @@ module.exports = ->
   @loadNpmTasks 'grunt-istanbul'
 
   # Inject the Istanbul Traceur version to provide proper ES6 coverage.
-  task = require.cache[require.resolve('grunt-istanbul/node_modules/istanbul')]
+  task = require.cache[require.resolve('istanbul')]
   task.exports.Instrumenter = istanbulTraceur.Instrumenter
 
   @config 'instrument',


### PR DESCRIPTION
The istanbul upgrade within grunt-istanbul broke our expectation that it would always have a nested dependency.  I changed the resolver code in the istanbul task to resolve top-level.