### PR TITLE
Change contrib page

### DIFF
--- a/shared/scripts/lib/pages/donations/donations.html
+++ b/shared/scripts/lib/pages/donations/donations.html
@@ -14,7 +14,7 @@
     <table class="pure-table pure-table-bordered pure-table-striped">
       <thead>
         <tr>
-          <th>Host</th>
+          <th>Payee</th>
           <th>Name</th>
           <th>Time spent since last payment</th>
           <th>Recommendation</th>
@@ -34,17 +34,15 @@
                 data-dwolla="{{ author.dwolla }}"
                 data-paypal="{{ author.paypal }}"
                 data-host="{{ entry.author.hostname }}"
-                data-url="{{ entry.tab.url }}"
               >
             {%else%}
               <tr class="entry"
                 data-dwolla="{{ author.dwolla }}"
                 data-paypal="{{ author.paypal }}"
                 data-host="{{ entry.author.hostname }}"
-                data-url="{{ entry.tab.url }}"
               > 
               {%endif%}           
-          <td><a target="_blank" title="{{entry.tab.url}}" href="{{entry.tab.url}}">{{entry.tab.url}}</a></td>
+          <td><a target="_blank" title="{{entry.author.hostname}}" href="http://{{entry.author.hostname}}">{{entry.author.hostname}}</a></td>
           <td>{{author.name|or "Anonymous"}}</td>
           <td>{{entry.timeSpent|timeSpent}}</td>
           <td><input type="text" class="amount" value="${{entry.estimatedAmount}}"></td>

--- a/shared/scripts/lib/pages/donations/donations.html
+++ b/shared/scripts/lib/pages/donations/donations.html
@@ -6,7 +6,7 @@
     <p class="info">
       <i class="fa fa-info-circle"></i>
 
-      Here you can pay your calculated contributions or customize the amount. 
+      Here you can pay your calculated contributions or customize the amount. Click on a payee's row to get a detailed list.
     </p>
     <p>
     <span id="moreButton" class="hide show pure-button">{%if hidden%} Show more {%else%} Hide {%endif%}</span>
@@ -42,9 +42,9 @@
                 data-host="{{ entry.author.hostname }}"
               > 
               {%endif%}           
-          <td><a target="_blank" title="{{entry.author.hostname}}" href="http://{{entry.author.hostname}}">{{entry.author.hostname}}</a></td>
-          <td>{{author.name|or "Anonymous"}}</td>
-          <td>{{entry.timeSpent|timeSpent}}</td>
+          <td class="clickable"><a target="_blank" title="{{entry.author.hostname}}" href="http://{{entry.author.hostname}}">{{entry.author.hostname}}</a></td>
+          <td class="clickable">{{author.name|or "Anonymous"}}</td>
+          <td class="clickable">{{entry.timeSpent|timeSpent}}</td>
           <td><input type="text" class="amount" value="${{entry.estimatedAmount}}"></td>
           <td class="relative">
             <div class="payment">

--- a/shared/scripts/lib/pages/donations/donations.js
+++ b/shared/scripts/lib/pages/donations/donations.js
@@ -48,6 +48,7 @@ DonationsPage.prototype = {
     'blur .amount': 'formatAndSave',
     'change .amount': 'formatAndSave',
     'click .remove': 'remove',
+    'click .removeInner': 'remove',
     'click .hide': 'toggleHidden',
     'click tbody tr td.clickable ': 'toggleEntryDonation',
     'mouseenter .remove': 'addHighlight',

--- a/shared/scripts/lib/pages/donations/donations.js
+++ b/shared/scripts/lib/pages/donations/donations.js
@@ -82,8 +82,8 @@ DonationsPage.prototype = {
   addHighlight: function(ev) {
     var curr = $(ev.currentTarget);
     if (curr.hasClass('entry')) {
-      curr.addClass("highlighted")
-      return
+      curr.addClass("highlighted");
+      return;
     } 
     if (curr.hasClass("remove")) {
       curr.closest('tr.entry').addClass("highlighted");
@@ -162,7 +162,7 @@ DonationsPage.prototype = {
          }
          
          if (dwollaToken && !payment.hasClass("d-btn")) {
-           payment.prepend(dwollaBtn(payment, amount, dwollaToken))
+           payment.prepend(dwollaBtn(payment, amount, dwollaToken));
          }
       });
       } else {

--- a/shared/scripts/lib/pages/donations/donations.js
+++ b/shared/scripts/lib/pages/donations/donations.js
@@ -4,6 +4,7 @@ import Component from '../../component';
 import storage from '../../storage';
 import calculate from '../../utils/calculate';
 import { inject as injectDwolla } from '../../processors/dwolla';
+import { getDwollaButton as dwollaBtn } from '../../processors/dwolla';
 import { inject as injectPaypal } from '../../processors/paypal';
 import { defaults } from '../../defaults';
 
@@ -48,8 +49,8 @@ DonationsPage.prototype = {
     'change .amount': 'formatAndSave',
     'click .remove': 'remove',
     'click .hide': 'toggleHidden',
-    'click tbody tr td.clickable ': 'toggleEntryDonation',
-    'click .entry-donation': 'cancelEvent'
+    'click tbody tr td.clickable ': 'toggleEntryDonation'
+   // 'click .entry-donation': 'cancelEvent'
   },
 
   filters: [
@@ -100,7 +101,7 @@ DonationsPage.prototype = {
         new Tablesort(component.$('tr.entry-donation table')[0], {
           descending: true
         });
-
+      
         component.$('tr.subentry').each(function() {
           var component = this;
           var $component = $(component);
@@ -126,6 +127,10 @@ DonationsPage.prototype = {
           // Only inject if the author has paypal.
           if (paypalToken) {
             $component.data().paypal = injectPaypal(payment, amount, paypalToken);
+         }
+         
+         if (dwollaToken && !payment.hasClass("d-btn")) {
+           payment.prepend(dwollaBtn(payment, amount, dwollaToken))
          }
       });
       } else {
@@ -299,8 +304,12 @@ DonationsPage.prototype = {
 
     // Update any payment methods on this element.
     var row = $(ev.currentTarget).closest('tr.entry').data();
+    if (!row) {
+      row = $(ev.currentTarget).closest('tr.subentry').data();
+    }
 
     if (row.dwolla) {
+
       row.dwolla.update(currency);
     }
 
@@ -442,6 +451,7 @@ DonationsPage.prototype = {
         // Only inject if the author has dwolla.
         if (dwollaToken) {
           $component.data().dwolla = injectDwolla(payment, amount, dwollaToken);
+         
         }
 
         // Only inject if the author has paypal.

--- a/shared/scripts/lib/pages/donations/donations.js
+++ b/shared/scripts/lib/pages/donations/donations.js
@@ -160,7 +160,6 @@ DonationsPage.prototype = {
   },
 
   remove: function(ev) {
-    console.log(ev);
     if (window.confirm('Are you sure you want to remove this entry from your contributions? This action cannot be undone.')) {
       var el = $(ev.currentTarget).closest('tr');
       var row = el.data();
@@ -271,11 +270,7 @@ DonationsPage.prototype = {
         */
             
         var tableSize = $('.pure-table tbody tr').length;
-        /*
-        if (tableSize <=1 ){
-          $('#text').html("Nobody to pay yet, get browsing!");
-        }
-        */
+
       }).catch(function(ex) {
         console.log(ex);
         console.log(ex.stack);
@@ -344,11 +339,8 @@ DonationsPage.prototype = {
           memo.forEach(function(entry) {
             // make sure it's not the daysVisited
             entry.host = key;
-            //console.log(entry)
             if (entry.tab && !entry.paid) {
               // If there is already an entry with the same url, update it.
-              //console.log("isDetailed:", isDetailed);
-              //console.log(entry);
               if (isDetailed === true) {
                 if (entry.author.hostname === current.author.hostname) {
                   entry.timeSpent += current.timeSpent;
@@ -406,13 +398,7 @@ DonationsPage.prototype = {
   },
 
   afterRender: function() {
-    /*
-   if (this.hidden === true) {
-      $(".hide").text("Show more")
-    } else if (this.hidden === false) {
-      $(".hide").text("Hide")      
-    }
-    */
+
     var tableSize = $('.pure-table tbody tr').length;
     if (tableSize <= defaults.maxDonationsTableSize) {
       $("#moreButton").hide() ;

--- a/shared/scripts/lib/pages/donations/donations.js
+++ b/shared/scripts/lib/pages/donations/donations.js
@@ -12,7 +12,8 @@ function DonationsPage() {
 
   // Set the default table data.
   this.data = {
-    entries: []
+    entries: [],
+    details: []
   };
 
   // Always attempt to render the inner table.
@@ -22,6 +23,20 @@ function DonationsPage() {
 
   // Whenever the data changes re-render the table.
   storage.onChange(this.renderTable.bind(this));
+  
+  var component = this;
+  
+  
+  this.entryDonation = this.fetch('pages/donations/entry-donation.html')
+  
+    .then(function(contents) {
+      var template = combyne(contents);
+      
+      [].concat(component.filters).forEach(function(filter) {
+        template.registerFilter(filter, component[filter]);  
+      });
+      return template;
+    });
 }
 
 DonationsPage.prototype = {
@@ -33,6 +48,8 @@ DonationsPage.prototype = {
     'change .amount': 'formatAndSave',
     'click .remove': 'remove',
     'click .hide': 'toggleHidden',
+    'click tbody tr': 'toggleEntryDonation',
+    'click .entry-donation': 'cancelEvent'
   },
 
   filters: [
@@ -52,6 +69,42 @@ DonationsPage.prototype = {
       return 1;
     }
     return 0;    
+  },
+  
+  toggleEntryDonation: function(ev) {
+    var component = this;
+    var tr = $(ev.currentTarget);
+    
+    if (tr.parents('th').length) {
+      return false;
+    } 
+    
+    if (!tr.hasClass('entry')) {
+      return false;
+    }
+
+    tr.toggleClass('active');
+    
+    this.entryDonation.then(function(template) {
+      var index = tr.data('host');
+      console.log("here")
+      //console.log(tr.data)
+      //console.log(component.data.entries)
+      //console.log(index)
+      //console.log(Number(tr.data('author')));
+     // console.log(component.data.details)
+     // console.log(index)
+      //console.log(component.data.details[0]);
+      if (tr.is('.active') && component.data.details[0]) {
+        console.log(component.data);
+        tr.after(template.render({entry: component.data}));
+        new Tablesort(component.$('tr.entry-donation table')[0], {
+          descending: true
+        });
+      } else {
+        tr.next('tr.entry-donation').remove();
+      }
+    });
   },
   
   toggleHidden: function(ev) {
@@ -80,27 +133,43 @@ DonationsPage.prototype = {
   },
 
   remove: function(ev) {
-  
+    console.log(ev);
     if (window.confirm('Are you sure you want to remove this entry from your contributions? This action cannot be undone.')) {
-  
-      var row = $(ev.currentTarget).closest('tr').data();
+      var el = $(ev.currentTarget).closest('tr');
+      var row = el.data();
       var host = row.host;
       var url = row.url;
-
-      storage.get('settings').then(function(settings) {
-        storage.get('log').then(function(resp) {
+      if (el.hasClass('entry')) {
+        storage.get('settings').then(function(settings) {
+          storage.get('log').then(function(resp) {
           // Filter out these items.
-          resp[host] = resp[host].filter(function(entry) {
-            if (entry.tab) {
-              return entry.tab.url !== url;
-            } else {
-              return entry;
-            }
+            resp[host] = resp[host].filter(function(entry) {
+              if (entry.tab) {
+                return entry.author.hostname !== host;
+              } else {
+                return entry;
+              }
+            });
+  
+            return storage.set('log', resp);
           });
-
-          return storage.set('log', resp);
         });
-      });
+      } else if (el.hasClass('subentry')) {
+        storage.get('settings').then(function(settings) {
+          storage.get('log').then(function(resp) {
+          // Filter out these items.
+            resp[host] = resp[host].filter(function(entry) {
+              if (entry.tab) {
+                return entry.tab.url !== url;
+              } else {
+                return entry;
+              }
+            });
+  
+            return storage.set('log', resp);
+          });
+        });        
+      }
     }
   },
 
@@ -117,7 +186,7 @@ DonationsPage.prototype = {
       storage.get('log').then(function(resp) {
         var filteredAndSorted = component
           // Convert the log Object to a filterable/sortable Array.
-          .toArray(resp, settings)
+          .toArray(resp, settings, true)
           // Sort and filter passing along the log component instance as
           // context.
           .filter(component.filter, component);
@@ -129,7 +198,7 @@ DonationsPage.prototype = {
         if (component.hidden) {
           var sortedNums = ents.map(function(o) {return Number(o.estimatedAmount);});
           for (var i = 0; i < entries.length; i++) {
-            if (sortedNums.indexOf(Number(entries[i].estimatedAmount)) > defaults.maxDonationsTableSize) {
+            if (sortedNums.indexOf(Number(entries[i].estimatedAmount)) >= defaults.maxDonationsTableSize) {
               entries[i].hidden = true;
             }
           }
@@ -151,12 +220,47 @@ DonationsPage.prototype = {
         console.log(ex.stack);
       });
     });
+    
+    storage.get('settings').then(function(settings) {
+      storage.get('log').then(function(resp) {
+        var filteredAndSorted = component
+          // Convert the log Object to a filterable/sortable Array.
+          .toArray(resp, settings, false)
+          // Sort and filter passing along the log component instance as
+          // context.
+          .filter(component.filter, component);
+
+        return filteredAndSorted;
+      }).then(function(entries) {
+        entries = entries.sort(component.sorter);
+        var ents = entries;
+ 
+        component.data.details = entries;
+        // This page hasn't been officially rendered yet.
+        /*
+        if (component.__rendered__) {
+          component.render();
+        }
+        */
+            
+        var tableSize = $('.pure-table tbody tr').length;
+        /*
+        if (tableSize <=1 ){
+          $('#text').html("Nobody to pay yet, get browsing!");
+        }
+        */
+      }).catch(function(ex) {
+        console.log(ex);
+        console.log(ex.stack);
+      });
+    });
   },
 
   serialize: function() {
     return {
       entries: this.data.entries,
-      hidden: this.data.hidden
+      hidden: this.data.hidden,
+      details: this.data.details
     };
   },
 
@@ -189,13 +293,16 @@ DonationsPage.prototype = {
    * @param resp
    * @return
    */
-  toArray: function(resp, settings) {
+  toArray: function(resp, settings, isDetailed) {
     var entries = [];
     var component = this;
 
     // Reset the data entries.
-    this.data.entries = [];
-
+    if (isDetailed === false) {
+      this.data.entries = [];
+    } else {
+      this.data.details = []
+    }
     // Resp is an object that is broken down by domain to list of entries
     // visited.  The most useful way to
     Object.keys(resp).forEach(function(key) {
@@ -210,11 +317,21 @@ DonationsPage.prototype = {
           memo.forEach(function(entry) {
             // make sure it's not the daysVisited
             entry.host = key;
+            //console.log(entry)
             if (entry.tab && !entry.paid) {
               // If there is already an entry with the same url, update it.
-              if (entry.tab.url === current.tab.url) {
-                entry.timeSpent += current.timeSpent;
-                isUpdated = true;
+              //console.log("isDetailed:", isDetailed);
+              //console.log(entry);
+              if (isDetailed === true) {
+                if (entry.author.hostname === current.author.hostname) {
+                  entry.timeSpent += current.timeSpent;
+                  isUpdated = true;
+                }
+              } else if (isDetailed === false){
+                if (entry.tab.url === current.tab.url) {
+                  entry.timeSpent += current.timeSpent;
+                  isUpdated = true;
+                }
               }
             }
           });
@@ -245,7 +362,7 @@ DonationsPage.prototype = {
 
         return memo;
       }, []);
-
+      
       entries.push.apply(entries, condensed);
     }, this);
 
@@ -322,7 +439,7 @@ DonationsPage.prototype = {
 
       });
 
-      return storage.set('settings', settings);
+      //return storage.set('settings', settings);
     }).catch(function(ex) {
       console.log(ex);
       console.log(ex.stack);

--- a/shared/scripts/lib/pages/donations/donations.js
+++ b/shared/scripts/lib/pages/donations/donations.js
@@ -49,8 +49,13 @@ DonationsPage.prototype = {
     'change .amount': 'formatAndSave',
     'click .remove': 'remove',
     'click .hide': 'toggleHidden',
-    'click tbody tr td.clickable ': 'toggleEntryDonation'
-   // 'click .entry-donation': 'cancelEvent'
+    'click tbody tr td.clickable ': 'toggleEntryDonation',
+    'mouseenter .remove': 'addHighlight',
+    'mouseenter .removeInner': 'addHighlight',
+    'mouseleave .remove': 'removeHighlight',
+    'mouseleave .removeInner': 'removeHighlight',
+    'mouseleave tr.entry': 'removeHighlight',
+    'mouseenter tr.entry': 'addHighlight',
   },
 
   filters: [
@@ -72,9 +77,35 @@ DonationsPage.prototype = {
     return 0;    
   },
   
+  // had to add these events because of CSS limitations. 
+  addHighlight: function(ev) {
+    var curr = $(ev.currentTarget);
+    if (curr.hasClass('entry')) {
+      curr.addClass("highlighted")
+      return
+    } 
+    if (curr.hasClass("remove")) {
+      curr.closest('tr.entry').addClass("highlighted");
+    } else if (curr.hasClass("removeInner")) {
+      curr.closest('tr.subentry').addClass("highlighted");
+    }
+  },
+  
+  removeHighlight: function(ev) {
+    var curr = $(ev.currentTarget);
+    if (curr.hasClass('entry')) {
+      curr.removeClass("highlighted");
+      return;
+    } 
+    if (curr.hasClass("remove")) {
+      curr.closest('tr.entry').removeClass("highlighted");
+    } else if (curr.hasClass("removeInner")) {
+      curr.closest('tr.subentry').removeClass("highlighted");
+    }
+  },
+  
   toggleEntryDonation: function(ev) {
     var component = this;
-    //console.log($(ev.currentTarget));
     var tr = $(($(ev.currentTarget)).parents()[0]);
     
     if (tr.parents('th').length) {
@@ -332,7 +363,7 @@ DonationsPage.prototype = {
     if (isDetailed === false) {
       this.data.entries = [];
     } else {
-      this.data.details = []
+      this.data.details = [];
     }
     // Resp is an object that is broken down by domain to list of entries
     // visited.  The most useful way to

--- a/shared/scripts/lib/pages/donations/donations.styl
+++ b/shared/scripts/lib/pages/donations/donations.styl
@@ -50,16 +50,24 @@ table
       top: 30px;
       right: -60px;
       margin-top: 0px;
+      
+    .removeInner
+      position: absolute;
+      top: 30px;
+      right: -60px;
+      margin-top: 0px;
 
   tr
     &:hover
       td
-        background-color #FCE6D2 !important
+        //background-color #FCE6D2 !important
       td.clickable
       		cursor pointer
 
 // Overrides for payment processors.
-
+.highlighted
+  td
+    background-color #FCE6D2 !important
 // Dwolla adjustments.
 .d-btn
   display inline-block

--- a/shared/scripts/lib/pages/donations/donations.styl
+++ b/shared/scripts/lib/pages/donations/donations.styl
@@ -36,6 +36,8 @@ table
     font-size 80%
 
   td
+  
+    border-top 1px solid #cbcbcb
     &.relative
       position relative
 

--- a/shared/scripts/lib/pages/donations/donations.styl
+++ b/shared/scripts/lib/pages/donations/donations.styl
@@ -53,6 +53,8 @@ table
     &:hover
       td
         background-color #FCE6D2 !important
+      td.clickable
+      		cursor pointer
 
 // Overrides for payment processors.
 
@@ -65,15 +67,14 @@ table
 form[name=_xclick]
   display inline-block
   margin-right 5px
-  
-  
+    
 .tooltip 
     display: inline;
-
 
 .tooltip:hover:after 
     color: #c00;
     text-decoration: none;
+
 tr.hidden
   display:none
 

--- a/shared/scripts/lib/pages/donations/entry-donation.html
+++ b/shared/scripts/lib/pages/donations/entry-donation.html
@@ -31,13 +31,12 @@
               No payment processors provided by this page.
             </div>
             <a href="#" class="tooltip" title="Click here to delete this entry">
-            <button class="remove pure-button">&#10007;</button>
+            <button class="removeInner pure-button">&#10007;</button>
             </a>
           </td>
         </tr>
           {%endeach%}
         {%endeach%}
-
       </tbody>
     </table>
   </td>

--- a/shared/scripts/lib/pages/donations/entry-donation.html
+++ b/shared/scripts/lib/pages/donations/entry-donation.html
@@ -1,0 +1,44 @@
+<tr class="entry-donation">
+  <td colspan="4">
+ <table class="pure-table pure-table-bordered pure-table-striped">
+      <thead>
+        <tr>
+          <th>URL</th>
+          <th>Time spent since last payment</th>
+          <th>Recommendation</th>
+          <th>Payment options</th>
+        </tr>
+      </thead>
+      <tbody>
+      <!--
+        <tr>
+          <td colspan="4" id="text">Nobody to pay yet.</td>
+        </tr>-->
+        {%each entry.details as visit%}
+        
+          {%each visit.author.list as author%}
+              <tr class="subentry"
+                data-dwolla="{{ author.dwolla }}"
+                data-paypal="{{ author.paypal }}"
+                data-host="{{ visit.author.hostname }}"
+                data-url="{{ visit.tab.url }}"
+              > 
+          <td><a target="_blank" title="{{visit.tab.url}}" href="{{visit.tab.url}}">{{visit.tab.url}}</a></td>
+          <td>{{visit.timeSpent|timeSpent}}</td>
+          <td><input type="text" class="amount" value="${{visit.estimatedAmount}}"></td>
+          <td class="relative">
+            <div class="payment">
+              No payment processors provided by this page.
+            </div>
+            <a href="#" class="tooltip" title="Click here to delete this entry">
+            <button class="remove pure-button">&#10007;</button>
+            </a>
+          </td>
+        </tr>
+          {%endeach%}
+        {%endeach%}
+
+      </tbody>
+    </table>
+  </td>
+</tr>

--- a/shared/scripts/lib/pages/log/log.js
+++ b/shared/scripts/lib/pages/log/log.js
@@ -105,7 +105,6 @@ LogPage.prototype = {
 
       // Only render the current entry.
       if (tr.is('.active') && component.data.entries[index]) {
-        console.log(component.data.entries[index]);
         tr.after(template.render({ entry: component.data.entries[index] }));
         // Enable table sorting.
         new Tablesort(component.$('tr.entry-history table')[0], {

--- a/shared/scripts/lib/pages/log/log.js
+++ b/shared/scripts/lib/pages/log/log.js
@@ -105,7 +105,7 @@ LogPage.prototype = {
 
       // Only render the current entry.
       if (tr.is('.active') && component.data.entries[index]) {
-      
+        console.log(component.data.entries[index]);
         tr.after(template.render({ entry: component.data.entries[index] }));
         // Enable table sorting.
         new Tablesort(component.$('tr.entry-history table')[0], {

--- a/shared/scripts/lib/processors/dwolla.js
+++ b/shared/scripts/lib/processors/dwolla.js
@@ -42,3 +42,22 @@ export function inject($el, amount, token) {
     }
   };
 }
+
+export function getDwollaButton($el, amount, token) {
+    var root = 'http://tipsy.csail.mit.edu/redirect';
+  var base = location.href.split('#')[0];
+  base = base.replace(/\//g, '$');
+  base = encodeURIComponent(base);
+
+  var redirect = [root, base, 'Dwolla user', amount].join('/');
+  var src = 'https://www.dwolla.com/scripts/button.min.js';
+
+  // If we're in testing, swap the token with our test account.
+  if (localStorage.testing === 'true') {
+    token = 'lYNGTjRZRQAU4j32+qB4fBAPNDTQQGeZHF9cZFrH+83qm21sTL';
+    src = base + '/../../vendor/dwolla.js';
+  }
+  
+  var retString = '<a class="d-btn d-btn-simple" href="https://developers.dwolla.com/button" data-key='+token+' data-redirect='+redirect+' data-label="Dwolla" data-name="Tipsy" data-description="Tipsy" data-amount='+amount+' data-shipping="0.00" data-tax="0.00" data-guest-checkout="true" data-type="simple"><span class="d-btn-text">Dwolla</span><span class="d-btn-icon"></span></a>';
+  return retString;
+}


### PR DESCRIPTION
Contributions page now shows per payee and upon expansion gives a more detailed view with the ability to pay separately. 

some styling issues for advice on which I am appealing to @tbranyen : 

(1) The dwolla buttons seems to like to hide on the expanded row entries. Could you please see why it hides the dowlla button? To reproduce: go to tbranyen.com. Go to 2 or 3 more links on that page. Make a rate that will generate a contribution. Go to the contributions page and click on the tbrnayen.com row. See how the dwolla button is hiding. It is not showing in any of the rows but it is there if you inspect.

I know you've worked in these stylings for the tables so perhaps you have a better idea than me why this is happening?

(2) In the same setup for reproduction as (1), see how hovering over one of the x's highlights all the rows. The sylesheet is (seemingly) setup to highlight only the relevant tr but it's not working. (Also the x's are slightly in an awkward position as well).

-ed: above 2 issues fixed and (1) was not a styling issue but a dwolla problem. so it fixes #84 