### PR TITLE
Allow building on chromium

### DIFF
--- a/build/tasks/shell.coffee
+++ b/build/tasks/shell.coffee
@@ -13,6 +13,8 @@ module.exports = ->
   # https://code.google.com/p/selenium/wiki/ChromeDriver#Requirements
   if process.platform is 'linux'
     chrome = '/usr/bin/google-chrome'
+    if not fs.existsSync chrome
+      chrome = '/usr/bin/chromium'
   else if process.platform is 'darwin'
     chrome = '"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"'
   else if process.platform is 'win32'


### PR DESCRIPTION
Previously, we'd only build with google-chrome (chromium + proprietary bits).
This commit allows tipsy to be built using chromium (the open source version of
chrome).