### PR TITLE
Keep crypto keys out of the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /firefox-extension/dist
 /cjs
 /test/coverage
+*.pem


### PR DESCRIPTION
Security measure to help avoid future situations like issue #101.