### PR TITLE
Enable unlimited storage

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -38,6 +38,7 @@
     "history",
     "idle",
     "storage",
+    "unlimitedStorage",
     "notifications",
     "https://www.dwolla.com/",
     "https://uat.dwolla.com/"


### PR DESCRIPTION
Per #100 this requests `unlimitedStorage` permissions as a temporary stop-gap to keep the application working & logging.