### PR TITLE
Don’t send HTTP Referer header from extension

### DIFF
--- a/shared/html/index.html
+++ b/shared/html/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="referrer" content="no-referrer">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>Tipsy</title>


### PR DESCRIPTION
Keep extension usage private. Unsets the HTTP Referer (sic) header when following external links from the extension settings page.