### PR TITLE
Require HTTPS before trusting publisher payment information

### DIFF
--- a/shared/scripts/lib/utils/tipsy-txt-parser.js
+++ b/shared/scripts/lib/utils/tipsy-txt-parser.js
@@ -85,7 +85,7 @@ export function parseTxt() {
     var req = new XMLHttpRequest();
     try {
       // Enforce HTTPS requirement when retrieving payment info.
-      req.open('GET', 'https://' . document.domain . '/tipsy.txt', false);
+      req.open('GET', 'https://' + document.domain + '/tipsy.txt', false);
     } catch (e) {
       
     }
@@ -110,6 +110,15 @@ export function parseTxt() {
         var serialInfo = JSON.parse(JSON.stringify(info)); // copy object or non-object without jquery
         serialInfo.prevTime = Date.now().toString();
         localStorage.setItem(document.domain, JSON.stringify(serialInfo));
+      }
+    } if (req.status == 304) {
+      info = localStorage.getItem(document.domain);
+      if (info !== undefined || info !== '') {
+        info = JSON.parse(info);
+        info.prevTime = Date.now().toString();
+        localStorage.setItem(document.domain, JSON.stringify(info));
+      } else {
+        localStorage.setItem(document.domain, JSON.stringify({'tipsyTried': Date.now()}));
       }
     } else {
       localStorage.setItem(document.domain, JSON.stringify({'tipsyTried': Date.now()}));

--- a/shared/scripts/lib/utils/tipsy-txt-parser.js
+++ b/shared/scripts/lib/utils/tipsy-txt-parser.js
@@ -80,10 +80,12 @@ export function parseTxt() {
     }
   }
 
+
   if (info == null || shouldRenew) {
     var req = new XMLHttpRequest();
-    try {  
-      req.open('GET', "/tipsy.txt", false);   
+    try {
+      // Enforce HTTPS requirement when retrieving payment info.
+      req.open('GET', 'https://' . document.domain . '/tipsy.txt', false);
     } catch (e) {
       
     }


### PR DESCRIPTION
Resolves issue #104 (which has the details about this).

(I also snuck in support for HTTP 304 caching.)